### PR TITLE
Fixed using @Autowired annotation in traits

### DIFF
--- a/Tests/DependencyInjection/Compiler/AutowiringCompilerPassMethodTest.php
+++ b/Tests/DependencyInjection/Compiler/AutowiringCompilerPassMethodTest.php
@@ -1,0 +1,70 @@
+<?php
+namespace Skrz\Bundle\AutowiringBundle\Tests\DependencyInjection\Compiler;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\PhpParser;
+use PHPUnit\Framework\TestCase;
+use Skrz\Bundle\AutowiringBundle\DependencyInjection\ClassMultiMap;
+use Skrz\Bundle\AutowiringBundle\DependencyInjection\Compiler\AutowiringCompilerPass;
+use Skrz\Bundle\AutowiringBundle\DependencyInjection\Compiler\ClassMapBuildCompilerPass;
+use Skrz\Bundle\AutowiringBundle\Tests\DependencyInjection\Compiler\AutowiringCompilerPassSource\AutowiredClassOverridesMethodTrait;
+use Skrz\Bundle\AutowiringBundle\Tests\DependencyInjection\Compiler\AutowiringCompilerPassSource\AutowiredClassUsesMethodTrait;
+use Skrz\Bundle\AutowiringBundle\Tests\DependencyInjection\Compiler\AutowiringCompilerPassSource\Foo\Bar;
+use Skrz\Bundle\AutowiringBundle\Tests\DependencyInjection\Compiler\AutowiringCompilerPassSource\Foo2\Bar2;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class AutowiringCompilerPassMethodTest extends TestCase
+{
+
+	public function testAutowireTraitMethod()
+	{
+		$containerBuilder = new ContainerBuilder();
+		$classMultiMap = new ClassMultiMap($containerBuilder);
+
+		$classMapBuildCompilerPass = new ClassMapBuildCompilerPass($classMultiMap);
+		$autowiringCompilerPass = new AutowiringCompilerPass($classMultiMap, new AnnotationReader(), new PhpParser());
+
+		$definition = $containerBuilder->setDefinition("service", new Definition(AutowiredClassUsesMethodTrait::class));
+		$containerBuilder->setDefinition("bar", new Definition(Bar::class));
+
+		$this->assertSame([], $definition->getMethodCalls());
+
+		$classMapBuildCompilerPass->process($containerBuilder);
+		$autowiringCompilerPass->process($containerBuilder);
+
+		$calls = $definition->getMethodCalls();
+		$this->assertCount(1, $calls);
+		$this->assertSame("setBar", $calls[0][0]);
+		$this->assertCount(1, $calls[0][1]);
+		$this->assertInstanceOf(Reference::class, $calls[0][1][0]);
+		$this->assertSame("bar", (string)$calls[0][1][0]);
+	}
+
+	public function testAutowireOverriddenTraitMethod()
+	{
+		$containerBuilder = new ContainerBuilder();
+		$classMultiMap = new ClassMultiMap($containerBuilder);
+
+		$classMapBuildCompilerPass = new ClassMapBuildCompilerPass($classMultiMap);
+		$autowiringCompilerPass = new AutowiringCompilerPass($classMultiMap, new AnnotationReader(), new PhpParser());
+
+		$definition = $containerBuilder->setDefinition("service", new Definition(AutowiredClassOverridesMethodTrait::class));
+		$containerBuilder->setDefinition("bar", new Definition(Bar::class));
+		$containerBuilder->setDefinition("bar2", new Definition(Bar2::class));
+
+		$this->assertSame([], $definition->getMethodCalls());
+
+		$classMapBuildCompilerPass->process($containerBuilder);
+		$autowiringCompilerPass->process($containerBuilder);
+
+		$calls = $definition->getMethodCalls();
+		$this->assertCount(1, $calls);
+		$this->assertSame("setBar", $calls[0][0]);
+		$this->assertCount(1, $calls[0][1]);
+		$this->assertInstanceOf(Reference::class, $calls[0][1][0]);
+		$this->assertSame("bar2", (string)$calls[0][1][0]);
+	}
+
+}

--- a/Tests/DependencyInjection/Compiler/AutowiringCompilerPassSource/AutowiredClassOverridesMethodTrait.php
+++ b/Tests/DependencyInjection/Compiler/AutowiringCompilerPassSource/AutowiredClassOverridesMethodTrait.php
@@ -1,0 +1,21 @@
+<?php
+namespace Skrz\Bundle\AutowiringBundle\Tests\DependencyInjection\Compiler\AutowiringCompilerPassSource;
+
+use Skrz\Bundle\AutowiringBundle\Annotation\Autowired;
+use Skrz\Bundle\AutowiringBundle\Tests\DependencyInjection\Compiler\AutowiringCompilerPassSource\Foo2\Bar2;
+
+class AutowiredClassOverridesMethodTrait
+{
+
+	use AutowiredMethodTrait;
+
+	/**
+	 * @param Bar2 $bar
+	 *
+	 * @Autowired
+	 */
+	public function setBar($bar)
+	{
+	}
+
+}

--- a/Tests/DependencyInjection/Compiler/AutowiringCompilerPassSource/AutowiredClassOverridesPropertyTrait.php
+++ b/Tests/DependencyInjection/Compiler/AutowiringCompilerPassSource/AutowiredClassOverridesPropertyTrait.php
@@ -1,0 +1,17 @@
+<?php
+namespace Skrz\Bundle\AutowiringBundle\Tests\DependencyInjection\Compiler\AutowiringCompilerPassSource;
+
+use Skrz\Bundle\AutowiringBundle\Annotation\Autowired;
+use Skrz\Bundle\AutowiringBundle\Tests\DependencyInjection\Compiler\AutowiringCompilerPassSource\Foo2\Bar2;
+
+class AutowiredClassOverridesPropertyTrait
+{
+	use AutowiredPropertyTrait;
+
+	/**
+	 * @var Bar2
+	 *
+	 * @Autowired
+	 */
+	public $property;
+}

--- a/Tests/DependencyInjection/Compiler/AutowiringCompilerPassSource/AutowiredClassUsesMethodTrait.php
+++ b/Tests/DependencyInjection/Compiler/AutowiringCompilerPassSource/AutowiredClassUsesMethodTrait.php
@@ -1,0 +1,7 @@
+<?php
+namespace Skrz\Bundle\AutowiringBundle\Tests\DependencyInjection\Compiler\AutowiringCompilerPassSource;
+
+class AutowiredClassUsesMethodTrait
+{
+	use AutowiredMethodTrait;
+}

--- a/Tests/DependencyInjection/Compiler/AutowiringCompilerPassSource/AutowiredClassUsesPropertyTrait.php
+++ b/Tests/DependencyInjection/Compiler/AutowiringCompilerPassSource/AutowiredClassUsesPropertyTrait.php
@@ -1,0 +1,7 @@
+<?php
+namespace Skrz\Bundle\AutowiringBundle\Tests\DependencyInjection\Compiler\AutowiringCompilerPassSource;
+
+class AutowiredClassUsesPropertyTrait
+{
+	use AutowiredPropertyTrait;
+}

--- a/Tests/DependencyInjection/Compiler/AutowiringCompilerPassSource/AutowiredMethodTrait.php
+++ b/Tests/DependencyInjection/Compiler/AutowiringCompilerPassSource/AutowiredMethodTrait.php
@@ -1,0 +1,20 @@
+<?php
+namespace Skrz\Bundle\AutowiringBundle\Tests\DependencyInjection\Compiler\AutowiringCompilerPassSource;
+
+use Skrz\Bundle\AutowiringBundle\Annotation\Autowired;
+use Skrz\Bundle\AutowiringBundle\Tests\DependencyInjection\Compiler\AutowiringCompilerPassSource\Foo\Bar;
+
+trait AutowiredMethodTrait
+{
+
+	/**
+	 * @param Bar $bar
+	 *
+	 * @Autowired
+	 */
+	public function setBar($bar)
+	{
+
+	}
+
+}

--- a/Tests/DependencyInjection/Compiler/AutowiringCompilerPassSource/AutowiredPropertyTrait.php
+++ b/Tests/DependencyInjection/Compiler/AutowiringCompilerPassSource/AutowiredPropertyTrait.php
@@ -1,0 +1,17 @@
+<?php
+namespace Skrz\Bundle\AutowiringBundle\Tests\DependencyInjection\Compiler\AutowiringCompilerPassSource;
+
+use Skrz\Bundle\AutowiringBundle\Annotation\Autowired;
+use Skrz\Bundle\AutowiringBundle\Tests\DependencyInjection\Compiler\AutowiringCompilerPassSource\Foo\Bar;
+
+trait AutowiredPropertyTrait
+{
+
+	/**
+	 * @var Bar
+	 *
+	 * @Autowired
+	 */
+	public $property;
+
+}

--- a/Tests/DependencyInjection/Compiler/AutowiringCompilerPassSource/Foo/Bar.php
+++ b/Tests/DependencyInjection/Compiler/AutowiringCompilerPassSource/Foo/Bar.php
@@ -1,0 +1,6 @@
+<?php
+namespace Skrz\Bundle\AutowiringBundle\Tests\DependencyInjection\Compiler\AutowiringCompilerPassSource\Foo;
+
+class Bar
+{
+}

--- a/Tests/DependencyInjection/Compiler/AutowiringCompilerPassSource/Foo2/Bar2.php
+++ b/Tests/DependencyInjection/Compiler/AutowiringCompilerPassSource/Foo2/Bar2.php
@@ -1,0 +1,6 @@
+<?php
+namespace Skrz\Bundle\AutowiringBundle\Tests\DependencyInjection\Compiler\AutowiringCompilerPassSource\Foo2;
+
+class Bar2
+{
+}


### PR DESCRIPTION
When property/method came from a trait, autowiring compiler pass used `use` statements from the class, not the trait. This change fixes the behavior.